### PR TITLE
Remove trait item import to fix compilation error

### DIFF
--- a/src/sndfile.rs
+++ b/src/sndfile.rs
@@ -38,7 +38,6 @@ use std::ptr;
 use std::ffi::CString;
 use std::ffi::CStr;
 use std::ops::BitOr;
-use std::ops::BitOr::*;
 use std::i32::*;
 use std::intrinsics::transmute;
 


### PR DESCRIPTION
Not sure if something changed in the Rust compiler since the last builds of this library but I couldn't compile it until I made this change.
