### PR TITLE
Fixes for Mac OS

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,8 +1,8 @@
-#[cfg(unix)]
+#[cfg(target_os = "linux")]
 fn main() {
     println!("cargo:rustc-link-search=native=/usr/local/opt/openal-soft/lib");
     println!("cargo:rustc-link-search=native=/usr/local/lib");
 }
 
-#[cfg(not(unix))]
+#[cfg(not(target_os = "linux"))]
 fn main() {}

--- a/src/openal.rs
+++ b/src/openal.rs
@@ -26,6 +26,11 @@
 
 #![allow(dead_code, non_snake_case)]
 
+#[cfg(target_os = "macos")]
+#[link(name = "OpenAL", kind = "framework")]
+extern {}
+
+#[cfg(not(target_os = "macos"))]
 #[link(name = "openal")]
 extern {}
 


### PR DESCRIPTION
Somehow doesn't run yet, but builds.

```
   Compiling ears v0.3.5 (file:///private/tmp/ears)
   Compiling libc v0.2.16
    Finished debug [unoptimized + debuginfo] target(s) in 4.4 secs
     Running `target/debug/examples/many_sounds`
error: Process didn't exit successfully: `target/debug/examples/many_sounds` (signal: 11, SIGSEGV: invalid memory reference)
```
