### PR TITLE
Make building on Windows a bit easier

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ brew install openal-soft libsndfile
 
 ### Windows
 
+Install [MSYS2](http://www.msys2.org/) according to the instructions. Be sure to
+use the default installation folder (i.e. `C:\msys32` or `C:\msys64`), otherwise
+compiling won't work. Then, run the following in the MSYS2 shell:
+
 ```
 pacman -S mingw-w64-x86_64-libsndfile mingw-w64-x86_64-openal
 ```

--- a/build.rs
+++ b/build.rs
@@ -4,5 +4,15 @@ fn main() {
     println!("cargo:rustc-link-search=native=/usr/local/lib");
 }
 
-#[cfg(not(unix))]
+#[cfg(all(windows, target_arch = "x86"))]
+fn main () {
+    println!("cargo:rustc-link-search=native=C:\\msys32\\mingw64\\lib");
+}
+
+#[cfg(all(windows, target_arch = "x86_64"))]
+fn main () {
+    println!("cargo:rustc-link-search=native=C:\\msys64\\mingw64\\lib");
+}
+
+#[cfg(all(not(windows), not(unix)))]
 fn main() {}


### PR DESCRIPTION
I had some problems with the linker not finding libsndfile and OpenAL when building on Windows using the GNU toolchain. These commits should fix that, provided MSYS2 is installed in the default location.