### PR TITLE
Fix rare buffer exhaustion bug in looped music

### DIFF
--- a/src/music.rs
+++ b/src/music.rs
@@ -192,7 +192,7 @@ impl Music {
             let mut file : SndFile = port.recv().ok().unwrap();
             let mut samples = vec![0i16; sample_t_r as usize];
             let mut status = ffi::AL_PLAYING;
-            let mut i = 0;
+            let mut buffers_processed = 0;
             let mut buf = 0;
             let mut is_looping = is_looping_clone;
 
@@ -205,8 +205,8 @@ impl Music {
                     }
                     al::alGetSourcei(al_source,
                                      ffi::AL_BUFFERS_PROCESSED,
-                                     &mut i);
-                    if i != 0 {
+                                     &mut buffers_processed);
+                    if buffers_processed != 0 {
                         samples.clear();
                         al::alSourceUnqueueBuffers(al_source, 1, &mut buf);
                         let mut read = file.read_i16(&mut samples[..], sample_t_r as i64) *

--- a/src/music.rs
+++ b/src/music.rs
@@ -207,19 +207,24 @@ impl Music {
                                      ffi::AL_BUFFERS_PROCESSED,
                                      &mut buffers_processed);
                     if buffers_processed != 0 {
-                        samples.clear();
                         al::alSourceUnqueueBuffers(al_source, 1, &mut buf);
-                        let mut read = file.read_i16(&mut samples[..], sample_t_r as i64) *
-                                       mem::size_of::<i16>() as i64;
-                        if is_looping && read == 0 {
+                        let read = file.read_i16(&mut samples[..], sample_t_r as i64);
+
+                        if is_looping && read < sample_t_r as i64 {
+                            let additional_read = sample_t_r as i64 - read;
+
                             file.seek(0, SeekSet);
-                            read = file.read_i16(&mut samples[..], sample_t_r as i64) *
-                                   mem::size_of::<i16>() as i64;
+                            file.read_i16(&mut samples[read as usize..], additional_read);
+                        } else if read == 0 {
+                            // if we're not looping and we've reached
+                            // the end of the file, don't send any
+                            // more samples.
+                            samples.clear();
                         }
                         al::alBufferData(buf,
                                          sample_format,
                                          samples.as_ptr() as *mut c_void,
-                                         read as i32,
+                                         samples.len() as i32 * mem::size_of::<i16>() as i32,
                                          sample_rate);
                         al::alSourceQueueBuffers(al_source, 1, &buf);
                     }


### PR DESCRIPTION
Thanks for such a great library, I've been using it for a game I'm writing and it sure is convenient!

I have come across a very rare and annoying to track down bug that occurs when looping music.

Basically, what can happen is that if there are only a few bytes left right towards the end of reading a file, the next buffer to be queued won't be populated with enough data. By the time the thread wakes up again and attempts to re-fill the next buffer, OpenAL has already exhausted the few bytes filed in the previous buffer and put the source into an `AL_STOPPED` state. 

It is quite a rare occurrence, but it sure was frustrating having my music randomly stop playing!

My fix is fairly straight forward, I've basically modified the `samples` filling code to rewind the file and continue filling if we're looping and `samples` hasn't been completely filled yet. This should ensure that there's always enough data around by the time the thread wakes up again.

I'm sure there's a bit of opportunity for refactoring here, but I mainly focused on fixing the bug without changing too much.

There's also a demonstration of the issue here where I've increased the sleep time slightly, which increases the likelihood of it happening (it can still take a while to happen though):
https://github.com/jhasse/ears/compare/master...nickbrowne:looping-example