### PR TITLE
Add direct channel support to Audio Sources

### DIFF
--- a/examples/direct_channel.rs
+++ b/examples/direct_channel.rs
@@ -1,0 +1,59 @@
+extern crate ears;
+
+use std::io::stdin;
+use std::io::stdout;
+use std::io::Write;
+
+use ears::{Music, AudioController};
+
+fn main() {
+    // Read the inputs
+    let stdin = stdin();
+
+    print!("Insert the path to an audio file: ");
+    stdout().flush().ok();
+
+    let mut line = String::new();
+    stdin.read_line(&mut line).ok();
+    loop {
+        match &line[line.len()-1..] {
+            "\n" => { line.pop(); () },
+            "\r" => { line.pop(); () },
+            _ => { break; },
+        }
+    }
+
+    // Try to create the music
+    let mut music = Music::new(&line[..]).expect("Error loading music.");
+
+    // Play it
+    music.play();
+    music.set_looping(true);
+
+    let mut toggle = false;
+
+    loop {
+        music.set_direct_channel(toggle);
+
+        let direct_channel_enabled = music.get_direct_channel();
+
+        if direct_channel_enabled != toggle {
+            println!("Failed to enabled direct channel mode.");
+            println!("Extension may not be available.");
+        } else {
+            match direct_channel_enabled {
+                true => println!("Direct channel enabled."),
+                false => println!("Direct channel disabled."),
+            };
+        }
+
+        println!("Press enter to toggle direct channel mode, or 'x' to quit");
+        let mut cmd = String::new();
+        stdin.read_line(&mut cmd).ok();
+
+        match &cmd[..1] {
+            "x" => { music.stop(); break },
+            _ => toggle = !toggle,
+        };
+    }
+}

--- a/examples/simple_player.rs
+++ b/examples/simple_player.rs
@@ -62,7 +62,7 @@ fn main() {
             "p" => music.pause(),
             "s" => music.stop(),
             "x" => { music.stop(); break; },
-            _ => println!("Unknwon command.")
+            _ => println!("Unknown command.")
         }
         match music.get_state() {
             Playing => println!("State : Playing"),

--- a/src/audio_controller.rs
+++ b/src/audio_controller.rs
@@ -279,4 +279,41 @@ pub trait AudioController {
      * The current attenuation for the Audio Source in the range [0., 1.].
      */
     fn get_attenuation(&self) -> f32;
+
+    /**
+     * Enable or disable direct channel mode for an Audio Source.
+     *
+     * Sometimes audio tracks are authored with their own spatialization
+     * effects, where the AL's virtualization methods can cause a notable
+     * decrease in audio quality.
+     *
+     * The AL_SOFT_direct_channels extension provides a mechanism for
+     * applications to specify whether audio should be filtered according
+     * to the AL's channel virtualization rules for multi-channel buffers.
+     *
+     * When set to true, the audio channels are not virtualized and play
+     * directly on the matching output channels if they exist, otherwise
+     * they are dropped. Applies only when the extension exists and when
+     * playing non-mono buffers.
+     *
+     * http://kcat.strangesoft.net/openal-extensions/SOFT_direct_channels.txt
+     *
+     * The default is false.
+     *
+     * # Argument
+     * * `enabled` - true to enable direct channel mode, false to disable
+     */
+    fn set_direct_channel(&mut self, enabled: bool) -> ();
+
+    /**
+     * Returns whether direct channel is enabled or not.
+     *
+     * Will always return false if the AL_SOFT_direct_channels extension
+     * is not present.
+     *
+     * # Return
+     * `true` if source is using direct channel mode
+     * `false` otherwise
+     */
+    fn get_direct_channel(&self) -> bool;
 }

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -138,6 +138,17 @@ impl OpenAlData {
         }
     }
 
+    /// Check if AL_SOFT_direct_channels extension is present
+    ///
+    /// # Return
+    /// true if the extension is present, otherwise false.
+    pub fn direct_channel_capable() -> bool {
+        let c_str = CString::new("AL_SOFT_direct_channels").unwrap();
+        unsafe {
+            ffi::alIsExtensionPresent(c_str.as_ptr()) == ffi::AL_TRUE
+        }
+    }
+
     /// Check if the input context is created.
     ///
     /// This function check if the input OpenAl context is already created.

--- a/src/music.rs
+++ b/src/music.rs
@@ -673,6 +673,68 @@ impl AudioController for Music {
                          &mut attenuation);
         attenuation
     }
+
+    /**
+     * Enable or disable direct channel mode for a Music.
+     *
+     * Sometimes audio tracks are authored with their own spatialization
+     * effects, where the AL's virtualization methods can cause a notable
+     * decrease in audio quality.
+     *
+     * The AL_SOFT_direct_channels extension provides a mechanism for
+     * applications to specify whether audio should be filtered according
+     * to the AL's channel virtualization rules for multi-channel buffers.
+     *
+     * When set to true, the audio channels are not virtualized and play
+     * directly on the matching output channels if they exist, otherwise
+     * they are dropped. Applies only when the extension exists and when
+     * playing non-mono buffers.
+     *
+     * http://kcat.strangesoft.net/openal-extensions/SOFT_direct_channels.txt
+     *
+     * The default is false.
+     *
+     * # Argument
+     * * `enabled` - true to enable direct channel mode, false to disable
+     */
+    fn set_direct_channel(&mut self, enabled: bool) -> () {
+        if OpenAlData::direct_channel_capable() {
+            let value = match enabled {
+                true  => ffi::AL_TRUE,
+                false => ffi::AL_FALSE,
+            };
+
+            al::alSourcei(self.al_source, ffi::AL_DIRECT_CHANNELS_SOFT, value as i32);
+        }
+    }
+
+    /**
+     * Returns whether direct channel is enabled or not for a Music.
+     *
+     * Will always return false if the AL_SOFT_direct_channels extension
+     * is not present.
+     *
+     * # Return
+     * `true` if the Music is using direct channel mode
+     * `false` otherwise
+     */
+    fn get_direct_channel(&self) -> bool {
+        match OpenAlData::direct_channel_capable() {
+            true => {
+                let mut boolean = 0;
+                al::alGetSourcei(self.al_source,
+                                 ffi::AL_DIRECT_CHANNELS_SOFT,
+                                 &mut boolean);
+
+                match boolean as _ {
+                    ffi::ALC_TRUE  => true,
+                    ffi::ALC_FALSE => false,
+                    _              => unreachable!()
+                }
+            },
+            false => false,
+        }
+    }
 }
 
 

--- a/src/openal.rs
+++ b/src/openal.rs
@@ -133,6 +133,7 @@ pub mod ffi {
         pub fn alcCaptureSamples(devide: ALCdevicePtr, buffer: *mut c_void,sample: i32);
 
         /// extension check
+        pub fn alIsExtensionPresent(extension: *const c_char) -> ALboolean;
         pub fn alcIsExtensionPresent(device: ALCdevicePtr, extension: *const c_char) -> ALCboolean;
 
         /// Buffers functions

--- a/src/openal.rs
+++ b/src/openal.rs
@@ -34,9 +34,12 @@ pub mod ffi {
     use libc::{c_char, c_void, intptr_t };
 
     /// OpenAL types
+    pub type ALboolean = c_char;
     pub type ALCboolean = c_char;
     pub type ALCdevicePtr = intptr_t;
     pub type ALCcontextPtr = intptr_t;
+    pub const AL_TRUE:                ALboolean  = 1;
+    pub const AL_FALSE:               ALboolean  = 0;
     pub const ALC_TRUE:               ALCboolean  = 1;
     pub const ALC_FALSE:              ALCboolean  = 0;
 
@@ -66,6 +69,7 @@ pub mod ffi {
     pub const AL_BUFFER:              i32         = 0x1009;
     pub const AL_BUFFERS_PROCESSED:   i32         = 0x1016;
     pub const AL_BUFFERS_QUEUED:      i32         = 0x1015;
+    pub const AL_DIRECT_CHANNELS_SOFT:i32         = 0x1033;
 
     /// Error identifiers
     pub const AL_NO_ERROR:            i32         = 0;

--- a/src/sound.rs
+++ b/src/sound.rs
@@ -694,6 +694,67 @@ impl AudioController for Sound {
         attenuation
     }
 
+    /**
+     * Enable or disable direct channel mode for a Sound.
+     *
+     * Sometimes audio tracks are authored with their own spatialization
+     * effects, where the AL's virtualization methods can cause a notable
+     * decrease in audio quality.
+     *
+     * The AL_SOFT_direct_channels extension provides a mechanism for
+     * applications to specify whether audio should be filtered according
+     * to the AL's channel virtualization rules for multi-channel buffers.
+     *
+     * When set to true, the audio channels are not virtualized and play
+     * directly on the matching output channels if they exist, otherwise
+     * they are dropped. Applies only when the extension exists and when
+     * playing non-mono buffers.
+     *
+     * http://kcat.strangesoft.net/openal-extensions/SOFT_direct_channels.txt
+     *
+     * The default is false.
+     *
+     * # Argument
+     * * `enabled` - true to enable direct channel mode, false to disable
+     */
+    fn set_direct_channel(&mut self, enabled: bool) -> () {
+        if OpenAlData::direct_channel_capable() {
+            let value = match enabled {
+                true  => ffi::AL_TRUE,
+                false => ffi::AL_FALSE,
+            };
+
+            al::alSourcei(self.al_source, ffi::AL_DIRECT_CHANNELS_SOFT, value as i32);
+        }
+    }
+
+    /**
+     * Returns whether direct channel is enabled or not for a Sound.
+     *
+     * Will always return false if the AL_SOFT_direct_channels extension
+     * is not present.
+     *
+     * # Return
+     * `true` if the Sound is using direct channel mode
+     * `false` otherwise
+     */
+    fn get_direct_channel(&self) -> bool {
+        match OpenAlData::direct_channel_capable() {
+            true => {
+                let mut boolean = 0;
+                al::alGetSourcei(self.al_source,
+                                 ffi::AL_DIRECT_CHANNELS_SOFT,
+                                 &mut boolean);
+
+                match boolean as _ {
+                    ffi::ALC_TRUE  => true,
+                    ffi::ALC_FALSE => false,
+                    _              => unreachable!()
+                }
+            },
+            false => false,
+        }
+    }
 }
 
 //#[unsafe_destructor]


### PR DESCRIPTION
As discussed in https://github.com/jhasse/ears/issues/19, this adds functions to get and set direct channel mode for Sound and Music sources, so that people can choose to bypass virtualization and play sources directly on the matching output channels if available. 

I've tried my best to adhere to the existing code style for the sake of consistency, if anything isn't quite right just let me know.

I considered adding tests, but saw that most of the existing tests were being ignored. Happy to add them if needed.

I'd also considered modifying the `simple_player` example to add a direct channel toggle, but I felt I was ruining the "simple" aspect, so in the end I added a separate example.

I've tested this on Linux with OpenAL Soft 1.17, Windows with 1.18 soft and 1.1 core. All work as expected, with the setting safely being ignored on 1.1 as the extension doesn't exist.